### PR TITLE
reads pagination also from include and layout. remove posts subfield.

### DIFF
--- a/_includes/views/pagination.html
+++ b/_includes/views/pagination.html
@@ -1,14 +1,19 @@
-{%- if page.paginator -%}
+{%- assign params = include -%}
+{%- if include.paginator -%}
+  {%- assign paginator = include.paginator -%}
+{%- elsif layout.paginator -%}
+  {%- assign paginator = layout.paginator -%}
+{%- elsif page.paginator -%}
   {%- assign paginator = page.paginator -%}
 {%- elsif paginator == nil -%}
-  {%- assign paginator = site -%}
+  {%- assign paginator = site.posts -%}
 {%- endif -%}
 
-{%- if paginator.posts.size > 0 -%}
+{%- if paginator.size > 0 -%}
 <div class="pagination">
   <!-- Post list links -->
   <ul class="post-list">
-    {%- for post in paginator.posts -%}
+    {%- for post in paginator -%}
     <li>
       {%- assign date_format = site.yat.date_format | default: "%b %-d, %Y" -%}
 
@@ -42,7 +47,7 @@
   </ul>
 
   <!-- Pagination links -->
-  {%- if paginator.posts.size < site.posts.size -%}
+  {%- if paginator.size < site.posts.size -%}
     {%- include views/paginator.html -%}
   {%- endif -%}
 </div>


### PR DESCRIPTION
I edited `pagination.html` to read the `paginator` parameter from a number of places. It really can't read from `page` because of all the nested layouts. 

I also had to flatten it and pass the `posts` array directly. Otherwise, I could not figure out how to send a filtered dynamic list of posts to it. So now I could call it like this:
```
  {% assign posts_no_posters = site.categories.CAT | where_exp: "post", "post.categories != 'posters'" %}
  {% include views/pagination2.html paginator=posts_no_posters %}
```

I searched in your code to see if there was a specific use case for your version. Does this break compatibility with code that you have? 