### PR TITLE
Fix href bug on post-tag in _includes/views/pagination.html

### DIFF
--- a/_includes/views/pagination.html
+++ b/_includes/views/pagination.html
@@ -34,7 +34,7 @@
       </p>
       <div class="post-tags">
         {%- for tag in post.tags -%}
-        <a class="post-tag" href="/tags.html#{{tag}}">#{{tag}}</a>
+        <a class="post-tag" href="{{ '/tags.html ' | relative_url }}#{{tag}}">#{{tag}}</a>
         {%- endfor -%}
       </div>
     </li>


### PR DESCRIPTION
The original hyperlink will fail when the {{ site.baseurl }} is not "/". I fixed the problem by applying liquid filter "relative_url" on the auto-generated code.