### PR TITLE
Fix footer/menu popup colours

### DIFF
--- a/_sass/yat/_layout.scss
+++ b/_sass/yat/_layout.scss
@@ -36,7 +36,8 @@ html {
     }
 
     footer.site-footer {
-      background-color: $theme-color;
+      color: unset;
+      background-color: transparent;
 
       .site-footer-inner {
         border-top: solid 1px #eee;

--- a/_sass/yat/_layout.scss
+++ b/_sass/yat/_layout.scss
@@ -23,7 +23,7 @@ html {
 
         @include media-query($on-laptop) {
           .page-link {
-            color: unset;
+            color: $header-text-color;
           }
 
           .menu-icon {
@@ -36,7 +36,7 @@ html {
     }
 
     footer.site-footer {
-      background-color: transparent;
+      background-color: $theme-color;
 
       .site-footer-inner {
         border-top: solid 1px #eee;


### PR DESCRIPTION
When using a dark theme colour (coolblack; spacegrey):
- the home-page main popup menu (eg on a phone) has a dark grey background and black text
- the footer background is not applied, giving white text on a white background

This fix aims to solve these two issues.

CSS is NOT my thing, and I don't know your intention using `unset` and `transparent` - but this change at least appears correct.

Thanks for the theme - it's sooo good!