### PR TITLE
feat: re-format copyright message and auto increase copyright end year based on the current year

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@
 
 source "https://rubygems.org"
 gemspec
+

--- a/_config.yml
+++ b/_config.yml
@@ -27,7 +27,9 @@
 title: Your awesome title
 email: your-email@domain.com
 author: GitHub User
-copyright: Copyright © 1970-2010
+
+copyright: "Unpublished Work (cleft) 2017-{currentYear} {author}"
+
 description: >- # this means to ignore newlines until "baseurl:"
   Write an awesome description for your new site here. You can edit this
   line in _config.yml. It will appear in your document head meta (for

--- a/_config.yml
+++ b/_config.yml
@@ -28,6 +28,18 @@ title: Your awesome title
 email: your-email@domain.com
 author: GitHub User
 
+# Copyright setting
+# You can use any html code, currently below placeholders are available:
+# * current year: {currentYear}
+# * author: {author} (Value is the same as site.author)
+# * copyright: (c) - ©
+# * copyleft: (cleft)
+# * sound recording copyright: (p) - ℗ 
+#
+# For example:
+#   "Copyright (c) 2017-{currentYear} <a href="https://example.com">{author}</a>"
+#   "Copyright © 2017-2021 Foobar"
+#
 copyright: "Unpublished Work (cleft) 2017-{currentYear} {author}"
 
 description: >- # this means to ignore newlines until "baseurl:"

--- a/_includes/views/footer.html
+++ b/_includes/views/footer.html
@@ -3,7 +3,10 @@
 
   <div class="wrapper">
     <div class="site-footer-inner">
-      <div>{{ site.copyright }} {% if site.author %}@{{ site.author | escape }}{% endif %}</div>
+      <div>{% assign currYear = 'now' | date: "%Y" %}
+        {% assign currYearVar = '{currentYear}' %}
+        {% assign authorVar = '{author}' %}
+        {{ site.copyright | replace: '(c)', '&copy;' | replace: '(p)', '℗' | replace: '(cleft)', '<span class="copyleft">&copy;</span>' | replace: currYearVar, currYear | replace: authorVar, site.author}}</div>
       <div>Powered by <a title="Jekyll is a simple, blog-aware, static site
       generator." href="http://jekyllrb.com/">Jekyll</a> &amp; <a title="Yat, yet
       another theme." href="https://github.com/jeffreytse/jekyll-theme-yat">Yat Theme</a>.</div>

--- a/_includes/views/footer.html
+++ b/_includes/views/footer.html
@@ -3,10 +3,15 @@
 
   <div class="wrapper">
     <div class="site-footer-inner">
-      <div>{% assign currYear = 'now' | date: "%Y" %}
-        {% assign currYearVar = '{currentYear}' %}
-        {% assign authorVar = '{author}' %}
-        {{ site.copyright | replace: '(c)', '&copy;' | replace: '(p)', '℗' | replace: '(cleft)', '<span class="copyleft">&copy;</span>' | replace: currYearVar, currYear | replace: authorVar, site.author}}</div>
+      <div>
+        {%- assign currYear = 'now' | date: "%Y" -%}
+        {{ site.copyright
+            | replace: '{currentYear}', currYear
+            | replace: '{author}', site.author
+            | replace: '(c)', '&copy;'
+            | replace: '(p)', '℗'
+            | replace: '(cleft)', '<span class="copyleft">&copy;</span>'
+        }}</div>
       <div>Powered by <a title="Jekyll is a simple, blog-aware, static site
       generator." href="http://jekyllrb.com/">Jekyll</a> &amp; <a title="Yat, yet
       another theme." href="https://github.com/jeffreytse/jekyll-theme-yat">Yat Theme</a>.</div>

--- a/_sass/yat/_layout.scss
+++ b/_sass/yat/_layout.scss
@@ -210,6 +210,11 @@ html {
   }
 }
 
+.copyleft {
+  display: inline-block;
+  transform: rotate(180deg);
+}
+
 /**
  * Post header
  */


### PR DESCRIPTION
## Simple explanation:

![Screen Shot 2021-06-25 at 12 52 02 AM](https://user-images.githubusercontent.com/8257285/123391124-8aefbf80-d550-11eb-8d5b-a2893c0bcc85.png)

```yml
copyright: GitHub User
copyright_start_date: 2017
copyright_end_date: 2020
copyright_auto_increase: false 
# if set to true, the copyright end date will be overwritten and auto increased
```
