### PR TITLE
Use only text nodes for TOC

### DIFF
--- a/_includes/sidebar/article-menu.html
+++ b/_includes/sidebar/article-menu.html
@@ -25,10 +25,16 @@
     // Generate post menu
     var menuHTML = '';
     for (var i = 0; i < headings.length; i++) {
-      var h = headings[i];
-      menuHTML += (
-        '<li class="h-' + h.tagName.toLowerCase() + '">'
-        + '<a href="#h-' + h.getAttribute('id') + '">' + h.textContent + '</a></li>');
+      const h = headings[i];
+      let textContent = "";
+
+      h.childNodes.forEach((value) => {
+        if (value.nodeType === Node.TEXT_NODE) {
+          textContent += value.nodeValue;
+        }
+      });
+
+      menuHTML += `<li class="h-${h.tagName.toLowerCase()}"><a href="#h-${h.getAttribute('id')}">${textContent}</a></li>`;
     }
 
     menuContent.innerHTML = '<ul>' + menuHTML + '</ul>';


### PR DESCRIPTION
Current implementation of TOC use full `textContent`. However, if a heading contains footnote, the `textContent` will include the footnote index.

This PR sidesteps such issue by using only `TEXT_NODE`s for the display element of TOC.