### PR TITLE
support jemoji plugin

### DIFF
--- a/_sass/yat/_layout.scss
+++ b/_sass/yat/_layout.scss
@@ -434,6 +434,9 @@ html {
     img, svg, iframe {
       margin-left: auto;
       margin-right: auto;
+    }
+
+    img:not(.emoji), svg, iframe {
       display: block;
     }
 


### PR DESCRIPTION
https://github.com/jekyll/jemoji doesn't work on `layout: post` due to `img { display: block; }`. This PR fixes the issue

before | after
------ | ------
![image](https://user-images.githubusercontent.com/10780059/180602197-58ba8f21-cb9c-4598-b8e5-52829d6338de.png) | ![image](https://user-images.githubusercontent.com/10780059/180602181-d1989933-746b-45df-b130-d76cf5d74a3d.png)
