### PR TITLE
Excerpt size per post

### DIFF
--- a/_includes/views/pagination.html
+++ b/_includes/views/pagination.html
@@ -16,7 +16,7 @@
       {% assign lang = post.lang %}
       {%- include functions.html func='get_reading_time' -%}
       {% assign reading_time = return %}
-      {%- include functions.html func='get_article_excerpt' -%}
+      {%- include functions.html func='get_article_excerpt' excerpt_size=post.excerpt_size -%}
       {% assign excerpt = return %}
       {%- assign post_url = post.url | relative_url -%}
 


### PR DESCRIPTION
In the paginator, pass a `post.excerpt_size` variable to allow each post to specify a custom excerpt size in the front matter. For example:

```
---
title: My Awesome Post
layout: post
excerpt_size: 100
---
```

The site default will be respected otherwise, but this allows customization per-post as needed.