### PR TITLE
Fix: Wrap dividing operation with calc() in scss files

### DIFF
--- a/_sass/misc/article-menu.scss
+++ b/_sass/misc/article-menu.scss
@@ -17,7 +17,7 @@
   .post-menu-content {
     ul {
       border-left: 1px solid #e9ecef;
-      $indent: $base-font-size / 4;
+      $indent: calc($base-font-size / 4);
       $active-bgcolor: #ecebec;
 
       @for $i from 2 to 7 {

--- a/_sass/yat.scss
+++ b/_sass/yat.scss
@@ -42,8 +42,8 @@ $on-laptop:        800px !default;
 // Use media queries like this:
 // @include media-query($on-palm) {
 //   .wrapper {
-//     padding-right: $spacing-unit / 2;
-//     padding-left: $spacing-unit / 2;
+//     padding-right: calc($spacing-unit / 2);
+//     padding-left: calc($spacing-unit / 2);
 //   }
 // }
 @mixin media-query($device) {

--- a/_sass/yat/_base.scss
+++ b/_sass/yat/_base.scss
@@ -41,7 +41,7 @@ h1, h2, h3, h4, h5, h6,
 p, blockquote, pre,
 ul, ol, dl, figure,
 %vertical-rhythm {
-  margin-bottom: $spacing-unit / 2;
+  margin-bottom: calc($spacing-unit / 2);
 }
 
 
@@ -127,7 +127,7 @@ a {
 blockquote {
   color: $grey-color;
   border-left: 4px solid $grey-color-light;
-  padding-left: $spacing-unit / 2;
+  padding-left: calc($spacing-unit / 2);
   @include relative-font-size(1.125);
   letter-spacing: -1px;
   font-style: italic;
@@ -221,7 +221,7 @@ table {
   }
 
   th, td {
-    padding: ($spacing-unit / 3) ($spacing-unit / 2);
+    padding: calc($spacing-unit / 3) calc($spacing-unit / 2);
   }
 
   th {

--- a/_sass/yat/_layout.scss
+++ b/_sass/yat/_layout.scss
@@ -107,7 +107,7 @@ html {
 
     .site-favicon {
       display: inline-block;
-      height: $header-height / 1.5;
+      height: calc($header-height / 1.5);
       margin-right: 5px;
     }
   }
@@ -679,7 +679,7 @@ html {
   }
 
   @include media-query($on-palm) {
-    height: $banner-height / 1.5;
+    height: calc($banner-height / 1.5);
   }
 }
 


### PR DESCRIPTION
### ChangeList

- Wrap dividing operations (`something0 / something1)` with `calc()` function in `*.scss`
  - ex) `$base-font-size / 4` → `calc($base-font-size / 4)`

### Reason why

- Dividing operator(`/`) without `calc()` cause following warn logs
  - this operation is deprecated

```
Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($spacing-unit, 3) or calc($spacing-unit / 3)

More info and automated migrator: https://sass-lang.com/d/slash-div

    ╷
244 │     padding: ($spacing-unit / 3) ($spacing-unit / 2);
    │               ^^^^^^^^^^^^^^^^^
    ╵
    ../../../../minima-2.5.1/_sass/minima/_base.scss 244:15  @import
    minima.scss 48:3                                         @import
```