### PR TITLE
feat: show author for posts that specify one

### DIFF
--- a/_includes/views/pagination-item.html
+++ b/_includes/views/pagination-item.html
@@ -18,7 +18,7 @@
   <div class="post-meta">
     <span class="post-date"><i class="fa fa-calendar"></i> {{ post.date | date: date_format }}</span>
     {%- if post.author -%}
-    <span class="post-author left-vsplit"><i class="fa fa-user"></i> {{ post.author | escape }}</span>
+    <span class="post-author left-vsplit"><i class="fa fa-pencil"></i> {{ post.author | escape }}</span>
     {%- endif -%}
     <span class="post-reading-time left-vsplit"><i class="fa fa-clock-o"></i> {{ reading_time }}</span>
   </div>

--- a/_includes/views/pagination-item.html
+++ b/_includes/views/pagination-item.html
@@ -17,6 +17,9 @@
   </h2>
   <div class="post-meta">
     <span class="post-date"><i class="fa fa-calendar"></i> {{ post.date | date: date_format }}</span>
+    {%- if post.author -%}
+    <span class="post-author left-vsplit"><i class="fa fa-user"></i> {{ post.author | escape }}</span>
+    {%- endif -%}
     <span class="post-reading-time left-vsplit"><i class="fa fa-clock-o"></i> {{ reading_time }}</span>
   </div>
   <a class="post-excerpt" href="{{ post_url }}">

--- a/_includes/views/post-header.html
+++ b/_includes/views/post-header.html
@@ -8,6 +8,10 @@
       <i class="fa fa-calendar"></i> {{ page.date | date: date_format }}
     </time>
 
+    {%- if page.author -%}
+    <span class="post-author left-vsplit"><i class="fa fa-user"></i> {{ page.author | escape }}</span>
+    {%- endif -%}
+
     {% assign article = page.content %}
     {% assign lang = page.lang %}
     {%- include functions.html func='get_reading_time' -%}


### PR DESCRIPTION
Posts by default inherit the site's author, but it's possible to override that per post, which affects--e.g.--the RSS metadata. For posts that do so, we don't currently show that anywhere in the theme.

Add a new piece of metadata to posts, along with the date and reading time, that displays the author only when it's not inherited from the site.

This contribution is on behalf of my company.