### PR TITLE
Fix typo in Kramdown config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -235,7 +235,7 @@ yat:
 # Build settings
 # highlighter: none
 markdown: kramdown
-kmarkdown:
+kramdown:
   input: GFM
 
 plugins:


### PR DESCRIPTION
This key needs to be `kramdown`, not `kmarkdown`, to take effect. See [the documentation](https://jekyllrb.com/docs/configuration/markdown/). The string "kmarkdown" doesn't occur at all in Jekyll's source code.