### PR TITLE
Revert "fix: document does not have a valid `rel=canonical`"

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,7 +5,6 @@
   <meta name="google-translate-customization" content="108d9124921d80c3-80e20d618ff053c8-g4f02ec6f3dba68b7-c">
   {%- seo -%}
   <link rel="icon" href="{{ site.favicon }}">
-  <link rel="canonical" href="{{ site.url }}">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/typeface-noto-sans@0.0.72/index.min.css">
   <link rel="stylesheet" href="{{ "/assets/css/main.css" | relative_url }}">


### PR DESCRIPTION
The SEO plugin adds a rel="canonical", so when it's enabled this makes us emit multiple, which isn't allowed. When the SEO plugin isn't enabled, it's fine not to emit a rel="canonical", since that tag exists only for SEO.

Additionally, the value of this canonical tag is wrong. It always points to the root of the site, but it's supposed to point to the main URL of the current page.

This reverts commit f75cca29781611428a8e8a8e2ac9b170365120be.