### PR TITLE
feat: Enable hidden posts

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,7 +3,9 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="google-translate-customization" content="108d9124921d80c3-80e20d618ff053c8-g4f02ec6f3dba68b7-c">
-  {%- seo -%}
+  {%- unless page.hidden %}
+    {%- seo -%}
+  {%- endunless %}
   <link rel="icon" href="{{ site.favicon }}">
   <link rel="canonical" href="{{ site.url }}">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">

--- a/_includes/sidebar/common-list.html
+++ b/_includes/sidebar/common-list.html
@@ -6,20 +6,24 @@
   {%- assign field = include.field -%}
 {%- endif -%}
 
+{%- assign unhidden = site.posts | where_exp: "item", "item.hidden == nil or item.hidden == false" -%}
 <div class="common-list">
   <ul>
     <li>
       <a href="{{ '/index.html' | relative_url }}">
-        All<span>{{ site.posts.size }}</span>
+        All<span>{{ unhidden.size }}</span>
       </a>
     </li>
 
     {% for key in  keys %}
+      {%- assign items = unhidden | where: field, key %}
+      {%- if items.size > 0 %}
       <li>
         <a href="{{ url }}#h-{{ key }}">
-          {{ key }} <span>{{ site.posts | where: field, key | size }}</span>
+          {{ key }} <span>{{ items | size }}</span>
         </a>
       </li>
+      {%- endif -%}
     {% endfor %}
   </ul>
 </div>

--- a/_includes/views/pagination.html
+++ b/_includes/views/pagination.html
@@ -8,7 +8,7 @@
 {%- include functions.html func='get_value' default='z' -%}
 {%- assign image_style = return | append: '-image-style' -%}
 
-{%- if paginator.posts.size > 0 -%}
+{%- if paginator.next_page or paginator.previous_page -%}
 <div class="pagination">
   <!-- Post list links -->
   <ul class="post-list {{ image_style }}">

--- a/_includes/views/segments.html
+++ b/_includes/views/segments.html
@@ -10,7 +10,7 @@
   <ul class="page-segments-list">
     {% for key in keys %}
     <h2 id="{{ key }}" class="segment-name">{{ key }}</h2>
-      {% assign items = site.posts | where: field, key %}
+      {% assign items = site.posts | where_exp: "item", "item.hidden == nil or item.hidden == false" | where: field, key %}
       {% for item in items %}
         {% if item != nil %}
           {%- assign post_item_class = "" -%}

--- a/_layouts/about.html
+++ b/_layouts/about.html
@@ -1,6 +1,6 @@
 ---
 layout: post
-hidden:
+hide:
   - header
   - navigator
   - related_posts

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,7 +2,7 @@
 layout: framework
 banner:
 banner_html: post-header.html
-hidden: []
+hide: []
 sidebar:
   - article-menu
 ---
@@ -14,41 +14,62 @@ sidebar:
     {%- include functions.html func='get_value' -%}
     {%- assign banner = return -%}
 
-    {%- assign name = 'hidden' -%}
+    {%- assign name = 'hide' -%}
     {%- include functions.html func='get_value' -%}
-    {%- assign hidden = return -%}
+    {%- assign hide = return -%}
 
-    {%- assign result = hidden | where_exp: "item", "item == 'header'" -%}
+    {%- unless hide contains 'header' -%}
     {%- if banner == nil and result.size == 0 -%}
     {%- include views/post-header.html -%}
     {%- endif -%}
+    {%- endunless -%}
 
     {%- include views/article.html -%}
 
-    {%- assign result = hidden | where_exp: "item", "item == 'navigator'" -%}
-    {%- if result.size == 0 -%}
+    {%- unless hide contains 'navigator' -%}
     <div class="post-nav">
-      {%- if page.previous -%}
-        <a class="previous" href="{{ page.previous.url | relative_url }}" title="{{
-          page.previous.title | escape }}">{{ page.previous.title | escape | truncatewords: 6 }}</a>
+      {%- assign p = page.previous %}
+      {%- for i in (1..20) %}
+      {%- if p == nil %}
+      {%- break %}
+      {%- endif %}
+      {%- if p.hidden %}
+      {%- assign p = p.previous %}
+      {%- continue %}
+      {%- endif %}
+      {%- break %}
+      {%- endfor %}
+
+      {%- assign n = page.next %}
+      {%- for i in (1..20) %}
+      {%- if n == nil %}
+      {%- break %}
+      {%- endif %}
+      {%- if n.hidden %}
+      {%- assign n = n.next %}
+      {%- continue %}
+      {%- endif %}
+      {%- break %}
+      {%- endfor %}
+      {%- if p -%}
+        <a class="previous" href="{{ p.url | relative_url }}" title="{{ p.title | escape }}">{{ p.title | escape | truncatewords: 6 }}</a>
       {%- else -%}
       <span></span>
       {%- endif -%}
 
-      {%- if page.next -%}
-        <a class="next" href="{{ page.next.url | relative_url }}" title="{{ page.next.title | escape }}">{{ page.next.title | escape | truncatewords: 6 }}</a>
+      {%- if n -%}
+        <a class="next" href="{{ n.url | relative_url }}" title="{{ n.title | escape }}">{{ n.title | escape | truncatewords: 6 }}</a>
       {%- else -%}
       <span></span>
       {%- endif -%}
     </div>
-    {%- endif -%}
+    {%- endunless -%}
 
-    {%- assign result = hidden | where_exp: "item", "item == 'related_posts'" -%}
-    {%- if result.size == 0 -%}
+    {%- unless hide contains 'related_posts'" -%}
     <div class="post-related">
       <div>Related Articles</div>
       <ul>
-        {% assign posts = site[page.collection] | sample:4 %}
+        {% assign posts = site[page.collection] | where_exp: "item", "item.hidden == nil or item.hidden == false" | sample:4 %}
         {%- for post in posts -%}
           {%- assign post_item_class = "" -%}
           {%- if post.top -%}
@@ -65,10 +86,9 @@ sidebar:
         {%- endfor -%}
       </ul>
     </div>
-    {%- endif -%}
+    {%- endunless -%}
 
-    {%- assign result = hidden | where_exp: "item", "item == 'comments'" -%}
-    {%- if result.size == 0 -%}
+    {%- unless hide contains 'comments' -%}
     <div class="post-comments">
       {%- if page.comments != false -%}
 
@@ -86,7 +106,7 @@ sidebar:
 
       {%- endif -%}
     </div>
-    {%- endif -%}
+    {%- endunless -%}
 
   </section>
 </div>


### PR DESCRIPTION
The 'hidden' attribute is by default used by Jekyll to exclude posts from paginator, to create unlisted pages, accessible only if url is known.

Current implementation uses 'hidden' to hide selected view sections like 'comments' or 'related posts.

This commit
- Renames existing `hidden` attribute to `hide`, to avoid conflict and restore Jekyll behavior.
- Applies hiding the post feature to navigator and other listings