### PR TITLE
style: Apply black background to photo-swipe on dark theme

### DIFF
--- a/_includes/extensions/photo-swipe.html
+++ b/_includes/extensions/photo-swipe.html
@@ -8,7 +8,12 @@
 />
 <style>
   .pswp .pswp__container .pswp__img {
+  html[data-theme="light"] {
     background-color: white;
+  }
+  html[data-theme="dark"] {
+    background-color: black;
+  }
   }
 </style>
 


### PR DESCRIPTION
Images with transparent background appear on a white page, even when dark theme is selected.

This sets the photo-swipe background to black on dark theme.